### PR TITLE
feat: stable migrations and connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ lerna-debug.log*
 
 
 # Other
-ormconfig.json
 .env
 
 # OS

--- a/ormconfig.ts
+++ b/ormconfig.ts
@@ -1,18 +1,17 @@
-import { Permission } from 'src/internal/entity/permission.entity';
-import { Role } from 'src/internal/entity/role.entity';
-import { User } from 'src/internal/entity/user.entity';
-import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
+import { DataSource, DataSourceOptions } from 'typeorm';
 
-export const PostgresDataSource: PostgresConnectionOptions = {
+const PostgresDataSource: DataSourceOptions = {
   type: 'postgres',
   host: 'db',
   port: 5432,
   username: 'postgres',
   password: 'password',
   database: 'test',
-  logging: true,
-  migrationsRun: false,
-  synchronize: true,
-  entities: [Permission, Role, User],
+  logging: false,
+  synchronize: false,
+  entities: ['dist/src/internal/entity/*.entity.js'],
+  migrations: ['dist/src/internal/migration/*.js'],
   migrationsTableName: 'migrations',
 };
+
+export const PostgresDataConnetion = new DataSource(PostgresDataSource);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "test:cov": "jest --coverage",
       "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
       "test:e2e": "jest --config ./test/jest-e2e.json",
-      "typeorm": "typeorm-ts-node-commonjs"
+      "typeorm": "typeorm-ts-node-commonjs -d ./ormconfig.ts"
    },
    "dependencies": {
       "@nestjs/common": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,7 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { PostgresDataSource } from 'ormconfig';
 import { AppController } from './app.controller';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(PostgresDataSource)],
   controllers: [AppController],
   providers: [],
 })

--- a/src/internal/migration/1657553500592-UserMigration.ts
+++ b/src/internal/migration/1657553500592-UserMigration.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserMigration1657553500592 implements MigrationInterface {
+  name = 'UserMigration1657553500592';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "permission" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, CONSTRAINT "PK_3b8b97af9d9d8807e41e6f48362" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "role" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, CONSTRAINT "UQ_ae4578dcaed5adff96595e61660" UNIQUE ("name"), CONSTRAINT "PK_b36bcfe02fc8de3c57a8b2391c2" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user" ("id" SERIAL NOT NULL, "email" character varying NOT NULL, "name" character varying NOT NULL, "password" character varying NOT NULL, CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "role_permissions_permission" ("role_id" integer NOT NULL, "permission_id" integer NOT NULL, CONSTRAINT "PK_32d63c82505b0b1d565761ae201" PRIMARY KEY ("role_id", "permission_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0167acb6e0ccfcf0c6c140cec4" ON "role_permissions_permission" ("role_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_2d3e8e7c82bdee8553b6f1e332" ON "role_permissions_permission" ("permission_id") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_roles_role" ("user_id" integer NOT NULL, "role_id" integer NOT NULL, CONSTRAINT "PK_cbb8cdf197992a93da55155c14e" PRIMARY KEY ("user_id", "role_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_09d115a69b6014d324d592f9c4" ON "user_roles_role" ("user_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0e2f5483d5e8d52043f9763453" ON "user_roles_role" ("role_id") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "role_permissions_permission" ADD CONSTRAINT "FK_0167acb6e0ccfcf0c6c140cec4a" FOREIGN KEY ("role_id") REFERENCES "role"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "role_permissions_permission" ADD CONSTRAINT "FK_2d3e8e7c82bdee8553b6f1e3325" FOREIGN KEY ("permission_id") REFERENCES "permission"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_roles_role" ADD CONSTRAINT "FK_09d115a69b6014d324d592f9c42" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_roles_role" ADD CONSTRAINT "FK_0e2f5483d5e8d52043f97634538" FOREIGN KEY ("role_id") REFERENCES "role"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_roles_role" DROP CONSTRAINT "FK_0e2f5483d5e8d52043f97634538"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_roles_role" DROP CONSTRAINT "FK_09d115a69b6014d324d592f9c42"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "role_permissions_permission" DROP CONSTRAINT "FK_2d3e8e7c82bdee8553b6f1e3325"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "role_permissions_permission" DROP CONSTRAINT "FK_0167acb6e0ccfcf0c6c140cec4a"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_0e2f5483d5e8d52043f9763453"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_09d115a69b6014d324d592f9c4"`,
+    );
+    await queryRunner.query(`DROP TABLE "user_roles_role"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_2d3e8e7c82bdee8553b6f1e332"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_0167acb6e0ccfcf0c6c140cec4"`,
+    );
+    await queryRunner.query(`DROP TABLE "role_permissions_permission"`);
+    await queryRunner.query(`DROP TABLE "user"`);
+    await queryRunner.query(`DROP TABLE "role"`);
+    await queryRunner.query(`DROP TABLE "permission"`);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { PostgresDataConnetion } from 'ormconfig';
+import { Logger } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -12,6 +14,16 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
+
+  const DatabaseLogger = new Logger('PostgresDatabase');
+
+  PostgresDataConnetion.initialize()
+    .then(() => {
+      DatabaseLogger.log('connection: SUCCESS');
+    })
+    .catch((err: Error) => {
+      DatabaseLogger.error(`'Database connection error: ${err}`);
+    });
 
   await app.listen(3000);
 }


### PR DESCRIPTION
Finally, I made fully working migrations and a connection to the database for TypeORM v0.3.6.
Migration was created by the command `npm run typeorm -- migration:generate <path>`